### PR TITLE
ci: use a pre-build image for semantic release

### DIFF
--- a/.github/workflows/check-application.yaml
+++ b/.github/workflows/check-application.yaml
@@ -46,5 +46,5 @@ jobs:
       - name: Eslint check
         run: pnpm lint:fix
 
-      - name: Commitisar check
-        uses: aevea/commitsar@v0.20.1
+      - name: Commitsar check
+        uses: docker://aevea/commitsar

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       
       - name: Release
-        uses: codfish/semantic-release-action@v2
+        uses: docker://ghcr.io/codfish/semantic-release-action:v2
         id: semantic
         with:
           branches: |


### PR DESCRIPTION
use a pre-build image from github repository to avoid build time